### PR TITLE
fix: CI submodule checkout missing + tokio::process in tui command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Run tests
@@ -46,6 +48,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -123,6 +127,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: true
       - uses: actions/setup-node@v4
         with:
           node-version: '18'

--- a/crates/core/src/commands/tui.rs
+++ b/crates/core/src/commands/tui.rs
@@ -1,16 +1,16 @@
 use anyhow::{Context, Result};
 use std::path::Path;
-use std::process::Command;
+use tokio::process::Command;
 
 use crate::output;
 
 const AIRSTACK_BANNER: &str = r#"
-     _    _         _             _    
+     _    _         _             _
     / \  (_)_ __ __| |_ __   ___ | | __
    / _ \ | | '__/ _` | '_ \ / _ \| |/ /
-  / ___ \| | | | (_| | |_) | (_) |   < 
+  / ___ \| | | | (_| | |_) | (_) |   <
  /_/   \_\_|_|  \__,_| .__/ \___/|_|\_\
-                     |_|                
+                     |_|
 "#;
 
 pub async fn run(view: Option<String>) -> Result<()> {
@@ -42,6 +42,7 @@ pub async fn run(view: Option<String>) -> Result<()> {
 
     let status = cmd
         .status()
+        .await
         .context("Failed to launch FrankenTUI showcase runner")?;
 
     if !status.success() {


### PR DESCRIPTION
## Description

Two bugs introduced in today's productionize + FrankenTUI integration commits (f9cc7f92, f4ee6b10):

- **CI broken**: all `actions/checkout@v4` steps are missing `submodules: true`. With `frankentui` now a git submodule, every CI job checks out the repo without submodule content — `cargo build` fails immediately with missing source files.
- **Tokio executor starved**: `tui.rs` used `std::process::Command::status()` (blocking) inside an `async fn`. Blocking a Tokio thread with a long-running child process can starve the executor. Fixed by switching to `tokio::process::Command` and `.await`.

## How to Test

1. Verify CI passes on this branch (test + build matrix jobs should now succeed with submodule content available)
2. Run `airstack tui` locally — confirm it launches FrankenTUI without blocking other async tasks
3. Confirm `cargo check` compiles cleanly with the `tokio::process` import